### PR TITLE
Avoid use of angular.element.scope()

### DIFF
--- a/src/js/w11k-flash.js
+++ b/src/js/w11k-flash.js
@@ -47,7 +47,7 @@ angular.module('w11k.flash').run(['$window', 'w11kFlashRegistry', function ($win
     $window.w11kFlashCall = function (flashId, expression, locals) {
       var flash = w11kFlashRegistry.getFlash(flashId);
       if (angular.isDefined(flash)) {
-        var scope = flash.element.scope();
+        var scope = flash.scope;
 
         // we have to evaluate the expression outside of an apply-function,
         // otherwise we are unable to return the result to flash
@@ -135,7 +135,8 @@ angular.module('w11k.flash').directive('w11kFlash', ['swfobject', '$window', '$q
 
       w11kFlashRegistry.registerFlash(flashId, {
         deferred: deferred,
-        element: element
+        element: element,
+        scope: scope
       });
 
       scope.$on('$destroy', function () {


### PR DESCRIPTION
We are using $compileProvider.debugInfoEnabled(false) in production builds and this breaks the scope lookup mechanism used to handle callbacks from flash.
This change attaches the scope to the lookup table and so avoids using angular's scope lookup.
